### PR TITLE
Keccak optimization phase 0

### DIFF
--- a/src/Keccak-compact-test.c
+++ b/src/Keccak-compact-test.c
@@ -15,6 +15,8 @@ http://creativecommons.org/publicdomain/zero/1.0/
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <limits.h>
+
 
 #ifdef VERBOSE
 #include <stdio.h>
@@ -108,6 +110,7 @@ void testKeccakInstanceBitLevel(unsigned int rate, unsigned int capacity, const 
 #endif
 
 unsigned long totalEvts = 0, nCalls = 0;
+unsigned long minLatency = ULONG_MAX, maxLatency = 0;
 
 void performTestByteLevel(unsigned int rate, unsigned int capacity, unsigned char delimitedSuffix, unsigned int outputByteLength, unsigned char *checksum)
 {
@@ -169,6 +172,8 @@ void performTestByteLevel(unsigned int rate, unsigned int capacity, unsigned cha
 #endif
     printf("%ld Keccak call(s) executed %ld instruction(s).\n", nCalls, totalEvts);
     printf("    - %.3e instruction(s) per call\n", totalEvts / (double) nCalls);
+    printf("    - min %ld instruction(s)\n", minLatency);
+    printf("    - max %ld instruction(s)\n", maxLatency);
 }
 
 void testKeccakInstanceByteLevel(unsigned int rate, unsigned int capacity, unsigned char delimitedSuffix, unsigned int outputByteLength, const unsigned char *expected)

--- a/src/Keccak-more-compact.c
+++ b/src/Keccak-more-compact.c
@@ -21,7 +21,7 @@ static void xor64(u8 *x, u64 u) { ui i; FOR(i,8) { x[i]^=u; u>>=8; } }
 #define wL(x,y,l) store64((u8*)s+8*(x+5*y),l)
 #define XL(x,y,l) xor64((u8*)s+8*(x+5*y),l)
 
-extern unsigned long totalEvts, nCalls;
+extern unsigned long totalEvts, nCalls, minLatency, maxLatency;
 
 /** return the value of the instret counter
  *
@@ -46,8 +46,11 @@ void KeccakF1600(void *s)
         /*ι*/ FOR(j,7) if (LFSR86540(&R)) XL(0,0,(u64)1<<((1<<j)-1));
     }
     stop = read_instret();
+    long cycleCnt = (stop - start);
     nCalls += 24;
-    totalEvts += (stop - start);
+    totalEvts += cycleCnt;
+    if (cycleCnt < minLatency) minLatency = cycleCnt;
+    if (cycleCnt > maxLatency) maxLatency = cycleCnt;
 }
 void Keccak(ui r, ui c, const u8 *in, u64 inLen, u8 sfx, u8 *out, u64 outLen)
 {

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,7 +3,7 @@
 # RISC-V C Compiler
 # available options (the version used must support RVV intrinsics)
 # clang/llvm
-CLANG_EXTRA_EXTS=_zvbb1p0
+CLANG_EXTRA_EXTS=_zvbb1p0_zbb_zbc_zba
 RISCVCC=clang  --target=riscv64 -I/opt/riscv/riscv64-unknown-elf/include/
 # GNU Compiler Collection (GCC)
 # RISCVCC=riscv64-unknown-elf-gcc 
@@ -19,7 +19,7 @@ PK_PATH=/opt/riscv/riscv64-unknown-elf/bin/pk64
 
 # SIMULATOR
 # Available options in the Docker (uncomment one)
-SIMULATOR=spike --isa=rv64gcv_zicntr_zihpm_zvbb --varch=vlen:$(VLEN),elen:64 $(PK_PATH)
+SIMULATOR=spike --isa=rv64gcv_zicntr_zihpm_zvbb_zbb_zbc_zba --varch=vlen:$(VLEN),elen:64 $(PK_PATH)
 # SIMULATOR=qemu-riscv64 -perfmap -cpu rv64,zba=true,v=on,vext_spec=v1.0,vlen=128,rvv_ta_all_1s=on
 
 CFLAGS ?= -O2

--- a/src/keccak-vector-wrapper.c
+++ b/src/keccak-vector-wrapper.c
@@ -215,7 +215,7 @@ int LFSR86540(uint8_t *LFSR)
 
 
 
-extern unsigned long totalEvts, nCalls;
+extern unsigned long totalEvts, nCalls, minLatency, maxLatency;
 
 /** return the value of the instret counter
  *
@@ -240,14 +240,18 @@ void KeccakF1600_StatePermute_vector(void *state)
 {
     unsigned int round;
 
-    unsigned long start, stop;
-    start = read_instret();
     for(round=0; round<24; round++) {
+        unsigned long start, stop;
+        start = read_instret();
         KeccakF1600_Round_vector(state, round);
+        stop = read_instret();
+        long cycleCnt = (stop - start);
+        nCalls++;
+        totalEvts += cycleCnt;
+        if (cycleCnt < minLatency) minLatency = cycleCnt;
+        if (cycleCnt > maxLatency) maxLatency = cycleCnt;
+
     }
-    stop = read_instret();
-    nCalls += 24;
-    totalEvts += (stop - start);
 }
 
 void KeccakF1600_StatePermute(void *state)

--- a/src/keccak-vector.c
+++ b/src/keccak-vector.c
@@ -130,12 +130,12 @@ void KeccakF1600_Round_vector(void *state, unsigned round)
     // matrix A to B
     // First 16 elements [0...15]
     vuint16m2_t B_index_0 = __riscv_vle16_v_u16m2(offset_AtoB, 16);
-    vuint64m8_t B_0 = __riscv_vluxei16_v_u64m8((uint64_t*)state, B_index_0, 16); // Note: pointer cast is not useful here
+    vuint64m8_t B_0 = __riscv_vluxei16_v_u64m8(state, B_index_0, 16);
     vuint64m8_t B_rots_0 = __riscv_vle64_v_u64m8(rotation_B, 16);
     B_0 = __riscv_vrol_vv_u64m8(B_0, B_rots_0, 16);
     // Last 9 elements [16...24]
     vuint16m2_t B_index_1 = __riscv_vle16_v_u16m2(offset_AtoB + 16, 9);
-    vuint64m8_t B_1 = __riscv_vluxei16_v_u64m8((uint64_t*)state, B_index_1, 9); // Note: pointer cast is not useful here
+    vuint64m8_t B_1 = __riscv_vluxei16_v_u64m8(state, B_index_1, 9);
     vuint64m8_t B_rots_1 = __riscv_vle64_v_u64m8(rotation_B + 16, 9);
     B_1 = __riscv_vrol_vv_u64m8(B_1, B_rots_1, 9);
     // To avoid state corruption, B partial results can only be stored once indexed load accesses


### PR DESCRIPTION
Various optimizations:
- Removing temporary memory buffer for rho and pi steps (using vector registers instead) + loop unrolling
- Improving performance monitoring to report min and max latencies (for rvv and more-compact implementation)
- Adding `Zbb`, `Zbc`, `Zba` extensions in default build options
- Minor improvements to theta step