### PR TITLE
[keccak-full-insn] wrapper to call keccak instruction directly

### DIFF
--- a/riscv-toolchain.Dockerfile
+++ b/riscv-toolchain.Dockerfile
@@ -75,6 +75,13 @@ RUN git submodule update --init --recursive
 WORKDIR $RISCV_SRCS/riscv-gnu-toolchain
 RUN make build-llvm -j5
 
+WORKDIR $RISCV_SRCS/riscv-gnu-toolchain/spike
+RUN git remote add nibrunieAtSi5 https://github.com/nibrunieAtSi5//riscv-isa-sim.git
+RUN git fetch nibrunieAtSi5
+RUN git checkout nibrunieAtSi5/keccak-full-insn
+WORKDIR $RISCV_SRCS/riscv-gnu-toolchain
+RUN make stamps/build-spike -j5
+RUN make install
 
 # Defaulting to the /home/app directory (where we are going to bind the rvv-examples directory)
 WORKDIR /home/app

--- a/src/Makefile
+++ b/src/Makefile
@@ -12,14 +12,14 @@ RISCVGNUCC=riscv64-unknown-elf-gcc
 
 # architectural parameters for the simulation
 # width of vector registers (VLEN)
-VLEN?=128
+VLEN?=256
 
 # path to proxy-kernel (pk)
 PK_PATH=/opt/riscv/riscv64-unknown-elf/bin/pk64 
 
 # SIMULATOR
 # Available options in the Docker (uncomment one)
-SIMULATOR=spike --isa=rv64gcv_zicntr_zihpm_zvbb_zbb_zbc_zba --varch=vlen:$(VLEN),elen:64 $(PK_PATH)
+SIMULATOR=spike --isa=rv64gcv_zicntr_zihpm_zvbb_zbb_zbc_zba_zvkk --varch=vlen:$(VLEN),elen:64 $(PK_PATH)
 # SIMULATOR=qemu-riscv64 -perfmap -cpu rv64,zba=true,v=on,vext_spec=v1.0,vlen=128,rvv_ta_all_1s=on
 
 CFLAGS ?= -O2

--- a/src/keccak-vector-custom-insn.c
+++ b/src/keccak-vector-custom-insn.c
@@ -1,0 +1,43 @@
+#include <riscv_vector.h>
+#include <stdio.h>
+#include <string.h>
+#include <inttypes.h>
+#include <assert.h>
+
+#include <keccak-vector-common.h>
+
+
+extern unsigned long totalEvts, nCalls, minLatency, maxLatency;
+
+/**
+ * Function that computes 24 Keccak-f[1600] permutation rounds on the given state.
+ * original from: https://github.com/XKCP/XKCP/blob/master/Standalone/CompactFIPS202/C/Keccak-readable-and-compact.c
+ */
+void KeccakF1600_StatePermute_vector(void *state)
+{
+    unsigned int round;
+
+    unsigned long start, stop;
+    start = read_instret();
+    unsigned long vl = 32;
+
+    __asm volatile (
+        "vsetivli x0, 25, e64, m8, tu, mu\n"
+        "vle64.v v8, 0(%[state])\n"
+        "vsetvli %[vl], %[vl], e64, m8, tu, mu\n"
+        // .insn r opc, func3, func7, vd, vs1, vs2
+        ".insn r 0x77, 0x2, 0x53, x8, x17, x24\n"
+        "vsetivli x0, 25, e64, m8, tu, mu\n"
+        "vse64.v v8, 0(%[state])\n"
+        : [vl]"+r"(vl)
+        : [state]"r"(state)
+        : 
+    );
+
+    stop = read_instret();
+    long cycleCnt = (stop - start);
+    nCalls += 24;
+    totalEvts += cycleCnt;
+    if (cycleCnt < minLatency) minLatency = cycleCnt;
+    if (cycleCnt > maxLatency) maxLatency = cycleCnt;
+}


### PR DESCRIPTION
Implementing benchmark using the prototype of multi-round Keccak instruction designed by https://github.com/mjosaarinen 

This implementation requires a custom `spike` version, built fromhttps://github.com/nibrunieAtSi5/riscv-isa-sim/pull/2.