### PR TITLE
Improving benchmarking capabilities

### DIFF
--- a/src/Keccak-compact-test.c
+++ b/src/Keccak-compact-test.c
@@ -17,6 +17,7 @@ http://creativecommons.org/publicdomain/zero/1.0/
 #include <string.h>
 #include <limits.h>
 
+#include "bench_utils.h"
 
 #ifdef VERBOSE
 #include <stdio.h>
@@ -24,16 +25,6 @@ http://creativecommons.org/publicdomain/zero/1.0/
 
 void Keccak(int rate, int capacity, const unsigned char *input, unsigned long long int inputByteLen, unsigned char delimitedSuffix, unsigned char *output, unsigned long long int outputByteLen);
 
-/** return the value of the instret counter
- *
- *  The instret counter counts the number of retired (executed) instructions.
-*/
-static unsigned long read_instret(void)
-{
-  unsigned long instret;
-  asm volatile ("rdinstret %0" : "=r" (instret));
-  return instret;
-}
 
 #ifdef TestAtBitLevel
 
@@ -110,7 +101,7 @@ void testKeccakInstanceBitLevel(unsigned int rate, unsigned int capacity, const 
 #endif
 
 unsigned long totalEvts = 0, nCalls = 0;
-unsigned long minLatency = ULONG_MAX, maxLatency = 0;
+unsigned long minPerfCount = ULONG_MAX, maxPerfCount = 0;
 
 void performTestByteLevel(unsigned int rate, unsigned int capacity, unsigned char delimitedSuffix, unsigned int outputByteLength, unsigned char *checksum)
 {
@@ -170,10 +161,10 @@ void performTestByteLevel(unsigned int rate, unsigned int capacity, unsigned cha
         printf("\n\n");
     }
 #endif
-    printf("%ld Keccak call(s) executed %ld instruction(s).\n", nCalls, totalEvts);
-    printf("    - %.3e instruction(s) per call\n", totalEvts / (double) nCalls);
-    printf("    - min %ld instruction(s)\n", minLatency);
-    printf("    - max %ld instruction(s)\n", maxLatency);
+    printf("%ld Keccak call(s) executed %ld " PERF_METRIC "(s).\n", nCalls, totalEvts);
+    printf("    - %.3e " PERF_METRIC "(s) per call\n", totalEvts / (double) nCalls);
+    printf("    - min %ld " PERF_METRIC "(s)\n", minPerfCount);
+    printf("    - max %ld " PERF_METRIC "(s)\n", maxPerfCount);
 }
 
 void testKeccakInstanceByteLevel(unsigned int rate, unsigned int capacity, unsigned char delimitedSuffix, unsigned int outputByteLength, const unsigned char *expected)

--- a/src/Keccak-more-compact-opt-in-regs.c
+++ b/src/Keccak-more-compact-opt-in-regs.c
@@ -1,3 +1,5 @@
+#include "bench_utils.h"
+
 // source: https://github.com/XKCP/XKCP/blob/master/Standalone/CompactFIPS202/C/Keccak-more-compact.c
 #define FOR(i,n) for(i=0; i<n; ++i)
 typedef unsigned char u8;
@@ -18,18 +20,8 @@ int LFSR86540(u8 *R) { (*R)=((*R)<<1)^(((*R)&0x80)?0x71:0); return ((*R)&2)>>1; 
 #define wL(x,y,l) do { ((u64*)s)[x+5*y] = l; } while (0)
 #define XL(x,y,l) do { ((u64*)s)[x+5*y] ^= l; } while (0)
 
-extern unsigned long totalEvts, nCalls, minLatency, maxLatency;
+extern unsigned long totalEvts, nCalls, minPerfCount, maxPerfCount;
 
-/** return the value of the instret counter
- *
- *  The instret counter counts the number of retired (executed) instructions.
-*/
-static unsigned long read_instret(void)
-{
-  unsigned long instret;
-  asm volatile ("rdinstret %0" : "=r" (instret));
-  return instret;
-}
 
 // round constants for ι step
 const u64 RC[25] = {
@@ -62,7 +54,7 @@ const u64 RC[25] = {
 void KeccakF1600(void *s)
 {
     unsigned long start, stop;
-    start = read_instret();
+    start = read_perf_counter();
     ui r,x,y,i,j,Y; u8 R=0x01; u64 C[5],D;
     // prolog: loading state
     u64 A_0_0 = rL(0, 0);
@@ -254,12 +246,12 @@ void KeccakF1600(void *s)
     wL(4, 2, A_4_2);
     wL(4, 3, A_4_3);
     wL(4, 4, A_4_4);
-    stop = read_instret();
-    long cycleCnt = (stop - start);
-    nCalls += 24;
-    totalEvts += cycleCnt;
-    if (cycleCnt < minLatency) minLatency = cycleCnt;
-    if (cycleCnt > maxLatency) maxLatency = cycleCnt;
+    stop = read_perf_counter();
+    long perfCnt = (stop - start);
+    nCalls++;
+    totalEvts += perfCnt;
+    if (perfCnt < minPerfCount) minPerfCount = perfCnt;
+    if (perfCnt > maxPerfCount) maxPerfCount = perfCnt;
 }
 void Keccak(ui r, ui c, const u8 *in, u64 inLen, u8 sfx, u8 *out, u64 outLen)
 {

--- a/src/Keccak-more-compact-opt.c
+++ b/src/Keccak-more-compact-opt.c
@@ -1,3 +1,5 @@
+#include "bench_utils.h"
+
 // source: https://github.com/XKCP/XKCP/blob/master/Standalone/CompactFIPS202/C/Keccak-more-compact.c
 #define FOR(i,n) for(i=0; i<n; ++i)
 typedef unsigned char u8;
@@ -18,18 +20,8 @@ int LFSR86540(u8 *R) { (*R)=((*R)<<1)^(((*R)&0x80)?0x71:0); return ((*R)&2)>>1; 
 #define wL(x,y,l) do { ((u64*)s)[x+5*y] = l; } while (0)
 #define XL(x,y,l) do { ((u64*)s)[x+5*y] ^= l; } while (0)
 
-extern unsigned long totalEvts, nCalls, minLatency, maxLatency;
+extern unsigned long totalEvts, nCalls, minPerfCount, maxPerfCount;
 
-/** return the value of the instret counter
- *
- *  The instret counter counts the number of retired (executed) instructions.
-*/
-static unsigned long read_instret(void)
-{
-  unsigned long instret;
-  asm volatile ("rdinstret %0" : "=r" (instret));
-  return instret;
-}
 
 // round constants for ι step
 const u64 RC[25] = {
@@ -62,7 +54,7 @@ const u64 RC[25] = {
 void KeccakF1600(void *s)
 {
     unsigned long start, stop;
-    start = read_instret();
+    start = read_perf_counter();
     ui r,x,y,i,j,Y; u8 R=0x01; u64 C[5],D;
     for(i=0; i<24; i++) {
 #       if 0
@@ -207,12 +199,12 @@ void KeccakF1600(void *s)
 #       endif
         /*ι*/ XL(0,0,RC[i]);
     }
-    stop = read_instret();
-    long cycleCnt = (stop - start);
-    nCalls += 24;
-    totalEvts += cycleCnt;
-    if (cycleCnt < minLatency) minLatency = cycleCnt;
-    if (cycleCnt > maxLatency) maxLatency = cycleCnt;
+    stop = read_perf_counter();
+    long perfCnt = (stop - start);
+    nCalls++;
+    totalEvts += perfCnt;
+    if (perfCnt < minPerfCount) minPerfCount = perfCnt;
+    if (perfCnt > maxPerfCount) maxPerfCount = perfCnt;
 }
 void Keccak(ui r, ui c, const u8 *in, u64 inLen, u8 sfx, u8 *out, u64 outLen)
 {

--- a/src/Keccak-more-compact.c
+++ b/src/Keccak-more-compact.c
@@ -1,3 +1,5 @@
+#include "bench_utils.h"
+
 // source: https://github.com/XKCP/XKCP/blob/master/Standalone/CompactFIPS202/C/Keccak-more-compact.c
 #define FOR(i,n) for(i=0; i<n; ++i)
 typedef unsigned char u8;
@@ -21,23 +23,13 @@ static void xor64(u8 *x, u64 u) { ui i; FOR(i,8) { x[i]^=u; u>>=8; } }
 #define wL(x,y,l) store64((u8*)s+8*(x+5*y),l)
 #define XL(x,y,l) xor64((u8*)s+8*(x+5*y),l)
 
-extern unsigned long totalEvts, nCalls, minLatency, maxLatency;
+extern unsigned long totalEvts, nCalls, minPerfCount, maxPerfCount;
 
-/** return the value of the instret counter
- *
- *  The instret counter counts the number of retired (executed) instructions.
-*/
-static unsigned long read_instret(void)
-{
-  unsigned long instret;
-  asm volatile ("rdinstret %0" : "=r" (instret));
-  return instret;
-}
 
 void KeccakF1600(void *s)
 {
     unsigned long start, stop;
-    start = read_instret();
+    start = read_perf_counter();
     ui r,x,y,i,j,Y; u8 R=0x01; u64 C[5],D;
     for(i=0; i<24; i++) {
         /*θ*/ FOR(x,5) C[x]=rL(x,0)^rL(x,1)^rL(x,2)^rL(x,3)^rL(x,4); FOR(x,5) { D=C[(x+4)%5]^ROL(C[(x+1)%5],1); FOR(y,5) XL(x,y,D); }
@@ -45,12 +37,12 @@ void KeccakF1600(void *s)
         /*χ*/ FOR(y,5) { FOR(x,5) C[x]=rL(x,y); FOR(x,5) wL(x,y,C[x]^((~C[(x+1)%5])&C[(x+2)%5])); }
         /*ι*/ FOR(j,7) if (LFSR86540(&R)) XL(0,0,(u64)1<<((1<<j)-1));
     }
-    stop = read_instret();
-    long cycleCnt = (stop - start);
-    nCalls += 24;
-    totalEvts += cycleCnt;
-    if (cycleCnt < minLatency) minLatency = cycleCnt;
-    if (cycleCnt > maxLatency) maxLatency = cycleCnt;
+    stop = read_perf_counter();
+    long perfCnt = (stop - start);
+    nCalls++;
+    totalEvts += perfCnt;
+    if (perfCnt < minPerfCount) minPerfCount = perfCnt;
+    if (perfCnt > maxPerfCount) maxPerfCount = perfCnt;
 }
 void Keccak(ui r, ui c, const u8 *in, u64 inLen, u8 sfx, u8 *out, u64 outLen)
 {

--- a/src/Makefile
+++ b/src/Makefile
@@ -5,11 +5,11 @@
 # clang/llvm
 CLANG_EXTRA_EXTS ?= _zvbb1p0_zbb_zbc_zba
 SPIKE_EXTRA_EXTS ?= _zvbb_zbb_zbc_zba
-RISCVCC=clang  --target=riscv64 -I/opt/riscv/riscv64-unknown-elf/include/
+RISCVCC=clang  --target=riscv64  # -I/opt/riscv/riscv64-unknown-elf/include/
 # GNU Compiler Collection (GCC)
 # RISCVCC=riscv64-unknown-elf-gcc 
 
-RISCVGNUCC=riscv64-unknown-elf-gcc 
+RISCVGNUCC ?= riscv64-unknown-elf-gcc 
 
 # architectural parameters for the simulation
 # width of vector registers (VLEN)

--- a/src/bench_utils.h
+++ b/src/bench_utils.h
@@ -1,0 +1,24 @@
+
+/** return the value of selected perf counter
+ * 
+ * perf counter is selected through a macro:
+ * - defining COUNT_INSTRET selects the instret counter
+ *    The instret counter counts the number of retired (executed) instructions.
+ * - defining COUNT_CYCLE selects cycle count
+*/
+static unsigned long read_perf_counter(void)
+{
+  unsigned long counter_value;
+#if defined(COUNT_INSTRET)
+#define PERF_METRIC "instruction"
+  asm volatile ("rdinstret %0" : "=r" (counter_value));
+#elif defined(COUNT_CYCLE)
+#define PERF_METRIC "cycle"
+  asm volatile ("rdcycle %0" : "=r" (counter_value));
+#else
+  // instret is also the default
+#define PERF_METRIC "instruction"
+  asm volatile ("rdinstret %0" : "=r" (counter_value));
+#endif
+  return counter_value;
+}

--- a/src/keccak-vector-asm-wrapper.c
+++ b/src/keccak-vector-asm-wrapper.c
@@ -1,0 +1,38 @@
+#include <riscv_vector.h>
+#include <stdio.h>
+#include <string.h>
+#include <inttypes.h>
+#include <assert.h>
+
+#include "keccak-vector-common.h"
+
+#include "bench_utils.h"
+
+
+/** Declaration of RVV implementation of Keccak-F1600 round function 
+ *
+ * @param state input/output 1600-bit state 
+ * @param round round index (must verify 0 <= round < 24)
+ *
+*/
+void KeccakF1600_Round_vector(void *state, unsigned round);
+
+extern unsigned long totalEvts, nCalls, minPerfCount, maxPerfCount;
+
+void KeccakF1600_StatePermute_vector(void *state)
+{
+    unsigned int round;
+
+    for(round=0; round<24; round++) {
+        unsigned long start, stop;
+        start = read_perf_counter();
+        KeccakF1600_Round_vector(state, round);
+        stop = read_perf_counter();
+        long perfCnt = (stop - start);
+        nCalls++;
+        totalEvts += perfCnt;
+        if (perfCnt < minPerfCount) minPerfCount = perfCnt;
+        if (perfCnt > maxPerfCount) maxPerfCount = perfCnt;
+
+    }
+}

--- a/src/keccak-vector-asm.S
+++ b/src/keccak-vector-asm.S
@@ -1,0 +1,243 @@
+	.text
+	.attribute	4, 16
+	.attribute	5, "rv64i2p1_m2p0_a2p1_f2p2_d2p2_c2p0_v1p0_zicsr2p0_zifencei2p0_zba1p0_zbb1p0_zbc1p0_zvbb1p0_zve32f1p0_zve32x1p0_zve64d1p0_zve64f1p0_zve64x1p0_zvkb1p0_zvl128b1p0_zvl32b1p0_zvl64b1p0"
+	.file	"keccak-vector.c"
+	.section	.rodata.cst32,"aM",@progbits,32
+	.p2align	5, 0x0                          # -- Begin function KeccakF1600_Round_vector
+.LCPI0_0:
+	.half	0                               # 0x0
+	.half	48                              # 0x30
+	.half	96                              # 0x60
+	.half	144                             # 0x90
+	.half	192                             # 0xc0
+	.half	24                              # 0x18
+	.half	72                              # 0x48
+	.half	80                              # 0x50
+	.half	128                             # 0x80
+	.half	176                             # 0xb0
+	.half	8                               # 0x8
+	.half	56                              # 0x38
+	.half	104                             # 0x68
+	.half	152                             # 0x98
+	.half	160                             # 0xa0
+	.half	32                              # 0x20
+	.section	.rodata.cst16,"aM",@progbits,16
+	.p2align	4, 0x0
+.LCPI0_1:
+	.half	40                              # 0x28
+	.half	88                              # 0x58
+	.half	136                             # 0x88
+	.half	184                             # 0xb8
+	.half	16                              # 0x10
+	.half	64                              # 0x40
+	.half	112                             # 0x70
+	.half	120                             # 0x78
+	.text
+	.globl	KeccakF1600_Round_vector
+	.p2align	1
+	.type	KeccakF1600_Round_vector,@function
+KeccakF1600_Round_vector:               # @KeccakF1600_Round_vector
+# %bb.0:
+	addi	sp, sp, -64
+	vsetivli	zero, 5, e64, m4, ta, ma
+	vle64.v	v8, (a0)
+	addi	a5, a0, 40
+	vle64.v	v12, (a5)
+	addi	t0, a0, 80
+	vle64.v	v16, (t0)
+	addi	a7, a0, 120
+	vle64.v	v20, (a7)
+	addi	a6, a0, 160
+	vle64.v	v24, (a6)
+	vxor.vv	v28, v8, v12
+	vxor.vv	v0, v16, v20
+	vxor.vv	v28, v28, v24
+	vxor.vv	v28, v0, v28
+	vsetivli	zero, 1, e64, m4, ta, ma
+	vslidedown.vi	v0, v28, 4
+	vsetivli	zero, 5, e64, m4, ta, ma
+	vslideup.vi	v0, v28, 1
+	vslidedown.vi	v4, v28, 1
+	vslideup.vi	v4, v28, 4
+	vror.vi	v28, v4, 63
+	vxor.vv	v28, v28, v0
+	vxor.vv	v8, v8, v28
+	vxor.vv	v12, v12, v28
+	vxor.vv	v16, v16, v28
+	vxor.vv	v20, v20, v28
+	vxor.vv	v24, v24, v28
+	vse64.v	v8, (a0)
+	vse64.v	v12, (a5)
+	vse64.v	v16, (t0)
+	vse64.v	v20, (a7)
+	vse64.v	v24, (a6)
+	lui	a2, %hi(.LCPI0_0)
+	addi	a2, a2, %lo(.LCPI0_0)
+	vsetivli	zero, 16, e16, m2, ta, ma
+	vle16.v	v8, (a2)
+	addi	a2, sp, 14
+	vse16.v	v8, (a2)
+	lui	a3, %hi(.LCPI0_1)
+	addi	a3, a3, %lo(.LCPI0_1)
+	vsetivli	zero, 8, e16, m1, ta, ma
+	vle16.v	v8, (a3)
+	addi	a3, sp, 46
+	vse16.v	v8, (a3)
+	li	a4, 168
+	sh	a4, 62(sp)
+	vsetivli	zero, 16, e64, m8, ta, ma
+	vle16.v	v8, (a2)
+	vluxei16.v	v16, (a0), v8
+	lui	a2, %hi(.L__const.KeccakF1600_Round_vector.rotation_B)
+	addi	a2, a2, %lo(.L__const.KeccakF1600_Round_vector.rotation_B)
+	vle64.v	v8, (a2)
+	vrol.vv	v8, v16, v8
+	vsetivli	zero, 9, e64, m8, ta, ma
+	vle16.v	v16, (a3)
+	vluxei16.v	v24, (a0), v16
+	addi	a2, a2, 128
+	vle64.v	v16, (a2)
+	vrol.vv	v16, v24, v16
+	vsetivli	zero, 16, e64, m8, ta, ma
+	vse64.v	v8, (a0)
+	addi	a2, a0, 128
+	vsetivli	zero, 9, e64, m8, ta, ma
+	vse64.v	v16, (a2)
+	vsetivli	zero, 5, e64, m4, ta, ma
+	vle64.v	v8, (a0)
+	vsetivli	zero, 3, e64, m4, ta, ma
+	vslidedown.vi	v12, v8, 2
+	vsetivli	zero, 5, e64, m4, ta, ma
+	vslideup.vi	v12, v8, 3
+	vsetivli	zero, 4, e64, m4, ta, ma
+	vslidedown.vi	v16, v8, 1
+	vsetivli	zero, 5, e64, m4, ta, ma
+	vslideup.vi	v16, v8, 4
+	lui	a2, %hi(RC)
+	addi	a2, a2, %lo(RC)
+	sh3add.uw	a1, a1, a2
+	ld	a1, 0(a1)
+	vandn.vv	v12, v12, v16
+	vxor.vv	v8, v8, v12
+	vsetivli	zero, 1, e64, m4, tu, ma
+	vxor.vx	v8, v8, a1
+	vsetivli	zero, 5, e64, m4, ta, ma
+	vse64.v	v8, (a0)
+	vle64.v	v8, (a5)
+	vsetivli	zero, 3, e64, m4, ta, ma
+	vslidedown.vi	v12, v8, 2
+	vsetivli	zero, 5, e64, m4, ta, ma
+	vslideup.vi	v12, v8, 3
+	vsetivli	zero, 4, e64, m4, ta, ma
+	vslidedown.vi	v16, v8, 1
+	vsetivli	zero, 5, e64, m4, ta, ma
+	vslideup.vi	v16, v8, 4
+	vandn.vv	v12, v12, v16
+	vxor.vv	v8, v8, v12
+	vse64.v	v8, (a5)
+	vle64.v	v8, (t0)
+	vsetivli	zero, 3, e64, m4, ta, ma
+	vslidedown.vi	v12, v8, 2
+	vsetivli	zero, 5, e64, m4, ta, ma
+	vslideup.vi	v12, v8, 3
+	vsetivli	zero, 4, e64, m4, ta, ma
+	vslidedown.vi	v16, v8, 1
+	vsetivli	zero, 5, e64, m4, ta, ma
+	vslideup.vi	v16, v8, 4
+	vandn.vv	v12, v12, v16
+	vxor.vv	v8, v8, v12
+	vse64.v	v8, (t0)
+	vle64.v	v8, (a7)
+	vsetivli	zero, 3, e64, m4, ta, ma
+	vslidedown.vi	v12, v8, 2
+	vsetivli	zero, 5, e64, m4, ta, ma
+	vslideup.vi	v12, v8, 3
+	vsetivli	zero, 4, e64, m4, ta, ma
+	vslidedown.vi	v16, v8, 1
+	vsetivli	zero, 5, e64, m4, ta, ma
+	vslideup.vi	v16, v8, 4
+	vandn.vv	v12, v12, v16
+	vxor.vv	v8, v8, v12
+	vse64.v	v8, (a7)
+	vle64.v	v8, (a6)
+	vsetivli	zero, 3, e64, m4, ta, ma
+	vslidedown.vi	v12, v8, 2
+	vsetivli	zero, 5, e64, m4, ta, ma
+	vslideup.vi	v12, v8, 3
+	vsetivli	zero, 4, e64, m4, ta, ma
+	vslidedown.vi	v16, v8, 1
+	vsetivli	zero, 5, e64, m4, ta, ma
+	vslideup.vi	v16, v8, 4
+	vandn.vv	v12, v12, v16
+	vxor.vv	v8, v8, v12
+	vse64.v	v8, (a6)
+	addi	sp, sp, 64
+	ret
+.Lfunc_end0:
+	.size	KeccakF1600_Round_vector, .Lfunc_end0-KeccakF1600_Round_vector
+                                        # -- End function
+	.type	RC,@object                      # @RC
+	.section	.rodata,"a",@progbits
+	.globl	RC
+	.p2align	3, 0x0
+RC:
+	.quad	1                               # 0x1
+	.quad	32898                           # 0x8082
+	.quad	-9223372036854742902            # 0x800000000000808a
+	.quad	-9223372034707259392            # 0x8000000080008000
+	.quad	32907                           # 0x808b
+	.quad	2147483649                      # 0x80000001
+	.quad	-9223372034707259263            # 0x8000000080008081
+	.quad	-9223372036854743031            # 0x8000000000008009
+	.quad	138                             # 0x8a
+	.quad	136                             # 0x88
+	.quad	2147516425                      # 0x80008009
+	.quad	2147483658                      # 0x8000000a
+	.quad	2147516555                      # 0x8000808b
+	.quad	-9223372036854775669            # 0x800000000000008b
+	.quad	-9223372036854742903            # 0x8000000000008089
+	.quad	-9223372036854743037            # 0x8000000000008003
+	.quad	-9223372036854743038            # 0x8000000000008002
+	.quad	-9223372036854775680            # 0x8000000000000080
+	.quad	32778                           # 0x800a
+	.quad	-9223372034707292150            # 0x800000008000000a
+	.quad	-9223372034707259263            # 0x8000000080008081
+	.quad	-9223372036854742912            # 0x8000000000008080
+	.quad	2147483649                      # 0x80000001
+	.quad	-9223372034707259384            # 0x8000000080008008
+	.quad	0                               # 0x0
+	.size	RC, 200
+
+	.type	.L__const.KeccakF1600_Round_vector.rotation_B,@object # @__const.KeccakF1600_Round_vector.rotation_B
+	.p2align	3, 0x0
+.L__const.KeccakF1600_Round_vector.rotation_B:
+	.quad	0                               # 0x0
+	.quad	44                              # 0x2c
+	.quad	43                              # 0x2b
+	.quad	21                              # 0x15
+	.quad	14                              # 0xe
+	.quad	28                              # 0x1c
+	.quad	20                              # 0x14
+	.quad	3                               # 0x3
+	.quad	45                              # 0x2d
+	.quad	61                              # 0x3d
+	.quad	1                               # 0x1
+	.quad	6                               # 0x6
+	.quad	25                              # 0x19
+	.quad	8                               # 0x8
+	.quad	18                              # 0x12
+	.quad	27                              # 0x1b
+	.quad	36                              # 0x24
+	.quad	10                              # 0xa
+	.quad	15                              # 0xf
+	.quad	56                              # 0x38
+	.quad	62                              # 0x3e
+	.quad	55                              # 0x37
+	.quad	39                              # 0x27
+	.quad	41                              # 0x29
+	.quad	2                               # 0x2
+	.size	.L__const.KeccakF1600_Round_vector.rotation_B, 200
+
+	.ident	"clang version 18.0.0git (https://github.com/llvm/llvm-project.git 5cfc7b3342ce4de0bbe182b38baa8a71fc83f8f8)"
+	.section	".note.GNU-stack","",@progbits
+	.addrsig

--- a/src/keccak-vector-asm.S
+++ b/src/keccak-vector-asm.S
@@ -1,44 +1,12 @@
 	.text
 	.attribute	4, 16
-	.attribute	5, "rv64i2p1_m2p0_a2p1_f2p2_d2p2_c2p0_v1p0_zicsr2p0_zifencei2p0_zba1p0_zbb1p0_zbc1p0_zvbb1p0_zve32f1p0_zve32x1p0_zve64d1p0_zve64f1p0_zve64x1p0_zvkb1p0_zvl128b1p0_zvl32b1p0_zvl64b1p0"
+	.attribute	5, "rv64i2p1_m2p0_a2p1_f2p2_d2p2_c2p0_v1p0_zicsr2p0_zifencei2p0_zba1p0_zbb1p0_zbc1p0_zve32f1p0_zve32x1p0_zve64d1p0_zve64f1p0_zve64x1p0_zvl128b1p0_zvl32b1p0_zvl64b1p0"
 	.file	"keccak-vector.c"
-	.section	.rodata.cst32,"aM",@progbits,32
-	.p2align	5, 0x0                          # -- Begin function KeccakF1600_Round_vector
-.LCPI0_0:
-	.half	0                               # 0x0
-	.half	48                              # 0x30
-	.half	96                              # 0x60
-	.half	144                             # 0x90
-	.half	192                             # 0xc0
-	.half	24                              # 0x18
-	.half	72                              # 0x48
-	.half	80                              # 0x50
-	.half	128                             # 0x80
-	.half	176                             # 0xb0
-	.half	8                               # 0x8
-	.half	56                              # 0x38
-	.half	104                             # 0x68
-	.half	152                             # 0x98
-	.half	160                             # 0xa0
-	.half	32                              # 0x20
-	.section	.rodata.cst16,"aM",@progbits,16
-	.p2align	4, 0x0
-.LCPI0_1:
-	.half	40                              # 0x28
-	.half	88                              # 0x58
-	.half	136                             # 0x88
-	.half	184                             # 0xb8
-	.half	16                              # 0x10
-	.half	64                              # 0x40
-	.half	112                             # 0x70
-	.half	120                             # 0x78
-	.text
-	.globl	KeccakF1600_Round_vector
+	.globl	KeccakF1600_Round_vector        # -- Begin function KeccakF1600_Round_vector
 	.p2align	1
 	.type	KeccakF1600_Round_vector,@function
 KeccakF1600_Round_vector:               # @KeccakF1600_Round_vector
 # %bb.0:
-	addi	sp, sp, -64
 	vsetivli	zero, 5, e64, m4, ta, ma
 	vle64.v	v8, (a0)
 	addi	a5, a0, 40
@@ -59,7 +27,10 @@ KeccakF1600_Round_vector:               # @KeccakF1600_Round_vector
 	vslideup.vi	v0, v28, 1
 	vslidedown.vi	v4, v28, 1
 	vslideup.vi	v4, v28, 4
-	vror.vi	v28, v4, 63
+	vadd.vv	v28, v4, v4
+	li	a2, 63
+	vsrl.vx	v4, v4, a2
+	vor.vv	v28, v28, v4
 	vxor.vv	v28, v28, v0
 	vxor.vv	v8, v8, v28
 	vxor.vv	v12, v12, v28
@@ -71,33 +42,31 @@ KeccakF1600_Round_vector:               # @KeccakF1600_Round_vector
 	vse64.v	v16, (t0)
 	vse64.v	v20, (a7)
 	vse64.v	v24, (a6)
-	lui	a2, %hi(.LCPI0_0)
-	addi	a2, a2, %lo(.LCPI0_0)
-	vsetivli	zero, 16, e16, m2, ta, ma
-	vle16.v	v8, (a2)
-	addi	a2, sp, 14
-	vse16.v	v8, (a2)
-	lui	a3, %hi(.LCPI0_1)
-	addi	a3, a3, %lo(.LCPI0_1)
-	vsetivli	zero, 8, e16, m1, ta, ma
-	vle16.v	v8, (a3)
-	addi	a3, sp, 46
-	vse16.v	v8, (a3)
-	li	a4, 168
-	sh	a4, 62(sp)
+.Lpcrel_hi0:
+	auipc	a2, %pcrel_hi(.L__const.KeccakF1600_Round_vector.offset_AtoB)
+	addi	a2, a2, %pcrel_lo(.Lpcrel_hi0)
 	vsetivli	zero, 16, e64, m8, ta, ma
 	vle16.v	v8, (a2)
-	vluxei16.v	v16, (a0), v8
-	lui	a2, %hi(.L__const.KeccakF1600_Round_vector.rotation_B)
-	addi	a2, a2, %lo(.L__const.KeccakF1600_Round_vector.rotation_B)
-	vle64.v	v8, (a2)
-	vrol.vv	v8, v16, v8
+.Lpcrel_hi1:
+	auipc	a3, %pcrel_hi(.L__const.KeccakF1600_Round_vector.rotation_B)
+	addi	a3, a3, %pcrel_lo(.Lpcrel_hi1)
+	vle64.v	v16, (a3)
+	vluxei16.v	v24, (a0), v8
+	li	a4, 64
+	vrsub.vx	v8, v16, a4
+	vsll.vv	v16, v24, v16
+	vsrl.vv	v8, v24, v8
+	vor.vv	v8, v16, v8
+	addi	a2, a2, 32
 	vsetivli	zero, 9, e64, m8, ta, ma
-	vle16.v	v16, (a3)
-	vluxei16.v	v24, (a0), v16
-	addi	a2, a2, 128
-	vle64.v	v16, (a2)
-	vrol.vv	v16, v24, v16
+	vle16.v	v16, (a2)
+	addi	a2, a3, 128
+	vle64.v	v24, (a2)
+	vluxei16.v	v0, (a0), v16
+	vrsub.vx	v16, v24, a4
+	vsll.vv	v24, v0, v24
+	vsrl.vv	v16, v0, v16
+	vor.vv	v16, v24, v16
 	vsetivli	zero, 16, e64, m8, ta, ma
 	vse64.v	v8, (a0)
 	addi	a2, a0, 128
@@ -105,108 +74,113 @@ KeccakF1600_Round_vector:               # @KeccakF1600_Round_vector
 	vse64.v	v16, (a2)
 	vsetivli	zero, 5, e64, m4, ta, ma
 	vle64.v	v8, (a0)
-	vsetivli	zero, 3, e64, m4, ta, ma
-	vslidedown.vi	v12, v8, 2
-	vsetivli	zero, 5, e64, m4, ta, ma
-	vslideup.vi	v12, v8, 3
 	vsetivli	zero, 4, e64, m4, ta, ma
-	vslidedown.vi	v16, v8, 1
+	vslidedown.vi	v12, v8, 1
 	vsetivli	zero, 5, e64, m4, ta, ma
-	vslideup.vi	v16, v8, 4
-	lui	a2, %hi(RC)
-	addi	a2, a2, %lo(RC)
+	vslideup.vi	v12, v8, 4
+	vnot.v	v12, v12
+	vsetivli	zero, 3, e64, m4, ta, ma
+	vslidedown.vi	v16, v8, 2
+	vsetivli	zero, 5, e64, m4, ta, ma
+	vslideup.vi	v16, v8, 3
+.Lpcrel_hi2:
+	auipc	a2, %pcrel_hi(RC)
+	addi	a2, a2, %pcrel_lo(.Lpcrel_hi2)
 	sh3add.uw	a1, a1, a2
 	ld	a1, 0(a1)
-	vandn.vv	v12, v12, v16
+	vand.vv	v12, v12, v16
 	vxor.vv	v8, v8, v12
 	vsetivli	zero, 1, e64, m4, tu, ma
 	vxor.vx	v8, v8, a1
 	vsetivli	zero, 5, e64, m4, ta, ma
 	vse64.v	v8, (a0)
 	vle64.v	v8, (a5)
-	vsetivli	zero, 3, e64, m4, ta, ma
-	vslidedown.vi	v12, v8, 2
-	vsetivli	zero, 5, e64, m4, ta, ma
-	vslideup.vi	v12, v8, 3
 	vsetivli	zero, 4, e64, m4, ta, ma
-	vslidedown.vi	v16, v8, 1
+	vslidedown.vi	v12, v8, 1
 	vsetivli	zero, 5, e64, m4, ta, ma
-	vslideup.vi	v16, v8, 4
-	vandn.vv	v12, v12, v16
+	vslideup.vi	v12, v8, 4
+	vnot.v	v12, v12
+	vsetivli	zero, 3, e64, m4, ta, ma
+	vslidedown.vi	v16, v8, 2
+	vsetivli	zero, 5, e64, m4, ta, ma
+	vslideup.vi	v16, v8, 3
+	vand.vv	v12, v12, v16
 	vxor.vv	v8, v8, v12
 	vse64.v	v8, (a5)
 	vle64.v	v8, (t0)
-	vsetivli	zero, 3, e64, m4, ta, ma
-	vslidedown.vi	v12, v8, 2
-	vsetivli	zero, 5, e64, m4, ta, ma
-	vslideup.vi	v12, v8, 3
 	vsetivli	zero, 4, e64, m4, ta, ma
-	vslidedown.vi	v16, v8, 1
+	vslidedown.vi	v12, v8, 1
 	vsetivli	zero, 5, e64, m4, ta, ma
-	vslideup.vi	v16, v8, 4
-	vandn.vv	v12, v12, v16
+	vslideup.vi	v12, v8, 4
+	vnot.v	v12, v12
+	vsetivli	zero, 3, e64, m4, ta, ma
+	vslidedown.vi	v16, v8, 2
+	vsetivli	zero, 5, e64, m4, ta, ma
+	vslideup.vi	v16, v8, 3
+	vand.vv	v12, v12, v16
 	vxor.vv	v8, v8, v12
 	vse64.v	v8, (t0)
 	vle64.v	v8, (a7)
-	vsetivli	zero, 3, e64, m4, ta, ma
-	vslidedown.vi	v12, v8, 2
-	vsetivli	zero, 5, e64, m4, ta, ma
-	vslideup.vi	v12, v8, 3
 	vsetivli	zero, 4, e64, m4, ta, ma
-	vslidedown.vi	v16, v8, 1
+	vslidedown.vi	v12, v8, 1
 	vsetivli	zero, 5, e64, m4, ta, ma
-	vslideup.vi	v16, v8, 4
-	vandn.vv	v12, v12, v16
+	vslideup.vi	v12, v8, 4
+	vnot.v	v12, v12
+	vsetivli	zero, 3, e64, m4, ta, ma
+	vslidedown.vi	v16, v8, 2
+	vsetivli	zero, 5, e64, m4, ta, ma
+	vslideup.vi	v16, v8, 3
+	vand.vv	v12, v12, v16
 	vxor.vv	v8, v8, v12
 	vse64.v	v8, (a7)
 	vle64.v	v8, (a6)
-	vsetivli	zero, 3, e64, m4, ta, ma
-	vslidedown.vi	v12, v8, 2
-	vsetivli	zero, 5, e64, m4, ta, ma
-	vslideup.vi	v12, v8, 3
 	vsetivli	zero, 4, e64, m4, ta, ma
-	vslidedown.vi	v16, v8, 1
+	vslidedown.vi	v12, v8, 1
 	vsetivli	zero, 5, e64, m4, ta, ma
-	vslideup.vi	v16, v8, 4
-	vandn.vv	v12, v12, v16
+	vslideup.vi	v12, v8, 4
+	vnot.v	v12, v12
+	vsetivli	zero, 3, e64, m4, ta, ma
+	vslidedown.vi	v16, v8, 2
+	vsetivli	zero, 5, e64, m4, ta, ma
+	vslideup.vi	v16, v8, 3
+	vand.vv	v12, v12, v16
 	vxor.vv	v8, v8, v12
 	vse64.v	v8, (a6)
-	addi	sp, sp, 64
 	ret
 .Lfunc_end0:
 	.size	KeccakF1600_Round_vector, .Lfunc_end0-KeccakF1600_Round_vector
                                         # -- End function
-	.type	RC,@object                      # @RC
+                                        # -- End function
+	.type	.L__const.KeccakF1600_Round_vector.offset_AtoB,@object # @__const.KeccakF1600_Round_vector.offset_AtoB
 	.section	.rodata,"a",@progbits
-	.globl	RC
-	.p2align	3, 0x0
-RC:
-	.quad	1                               # 0x1
-	.quad	32898                           # 0x8082
-	.quad	-9223372036854742902            # 0x800000000000808a
-	.quad	-9223372034707259392            # 0x8000000080008000
-	.quad	32907                           # 0x808b
-	.quad	2147483649                      # 0x80000001
-	.quad	-9223372034707259263            # 0x8000000080008081
-	.quad	-9223372036854743031            # 0x8000000000008009
-	.quad	138                             # 0x8a
-	.quad	136                             # 0x88
-	.quad	2147516425                      # 0x80008009
-	.quad	2147483658                      # 0x8000000a
-	.quad	2147516555                      # 0x8000808b
-	.quad	-9223372036854775669            # 0x800000000000008b
-	.quad	-9223372036854742903            # 0x8000000000008089
-	.quad	-9223372036854743037            # 0x8000000000008003
-	.quad	-9223372036854743038            # 0x8000000000008002
-	.quad	-9223372036854775680            # 0x8000000000000080
-	.quad	32778                           # 0x800a
-	.quad	-9223372034707292150            # 0x800000008000000a
-	.quad	-9223372034707259263            # 0x8000000080008081
-	.quad	-9223372036854742912            # 0x8000000000008080
-	.quad	2147483649                      # 0x80000001
-	.quad	-9223372034707259384            # 0x8000000080008008
-	.quad	0                               # 0x0
-	.size	RC, 200
+	.p2align	1, 0x0
+.L__const.KeccakF1600_Round_vector.offset_AtoB:
+	.half	0                               # 0x0
+	.half	48                              # 0x30
+	.half	96                              # 0x60
+	.half	144                             # 0x90
+	.half	192                             # 0xc0
+	.half	24                              # 0x18
+	.half	72                              # 0x48
+	.half	80                              # 0x50
+	.half	128                             # 0x80
+	.half	176                             # 0xb0
+	.half	8                               # 0x8
+	.half	56                              # 0x38
+	.half	104                             # 0x68
+	.half	152                             # 0x98
+	.half	160                             # 0xa0
+	.half	32                              # 0x20
+	.half	40                              # 0x28
+	.half	88                              # 0x58
+	.half	136                             # 0x88
+	.half	184                             # 0xb8
+	.half	16                              # 0x10
+	.half	64                              # 0x40
+	.half	112                             # 0x70
+	.half	120                             # 0x78
+	.half	168                             # 0xa8
+	.size	.L__const.KeccakF1600_Round_vector.offset_AtoB, 50
 
 	.type	.L__const.KeccakF1600_Round_vector.rotation_B,@object # @__const.KeccakF1600_Round_vector.rotation_B
 	.p2align	3, 0x0
@@ -238,6 +212,36 @@ RC:
 	.quad	2                               # 0x2
 	.size	.L__const.KeccakF1600_Round_vector.rotation_B, 200
 
-	.ident	"clang version 18.0.0git (https://github.com/llvm/llvm-project.git 5cfc7b3342ce4de0bbe182b38baa8a71fc83f8f8)"
+	.type	RC,@object                      # @RC
+	.p2align	3, 0x0
+RC:
+	.quad	1                               # 0x1
+	.quad	32898                           # 0x8082
+	.quad	-9223372036854742902            # 0x800000000000808a
+	.quad	-9223372034707259392            # 0x8000000080008000
+	.quad	32907                           # 0x808b
+	.quad	2147483649                      # 0x80000001
+	.quad	-9223372034707259263            # 0x8000000080008081
+	.quad	-9223372036854743031            # 0x8000000000008009
+	.quad	138                             # 0x8a
+	.quad	136                             # 0x88
+	.quad	2147516425                      # 0x80008009
+	.quad	2147483658                      # 0x8000000a
+	.quad	2147516555                      # 0x8000808b
+	.quad	-9223372036854775669            # 0x800000000000008b
+	.quad	-9223372036854742903            # 0x8000000000008089
+	.quad	-9223372036854743037            # 0x8000000000008003
+	.quad	-9223372036854743038            # 0x8000000000008002
+	.quad	-9223372036854775680            # 0x8000000000000080
+	.quad	32778                           # 0x800a
+	.quad	-9223372034707292150            # 0x800000008000000a
+	.quad	-9223372034707259263            # 0x8000000080008081
+	.quad	-9223372036854742912            # 0x8000000000008080
+	.quad	2147483649                      # 0x80000001
+	.quad	-9223372034707259384            # 0x8000000080008008
+	.quad	0                               # 0x0
+	.size	RC, 200
+
+	.ident	"clang version 18.1.8 (https://github.com/nibrunie/llvm-project.git 41f4d0c021746f0b8770ece91f712fd0795d0c90)"
 	.section	".note.GNU-stack","",@progbits
 	.addrsig

--- a/src/keccak-vector-in-reg.c
+++ b/src/keccak-vector-in-reg.c
@@ -6,8 +6,10 @@
 
 #include <keccak-vector-common.h>
 
+#include "bench_utils.h"
 
-extern unsigned long totalEvts, nCalls, minLatency, maxLatency;
+
+extern unsigned long totalEvts, nCalls, minPerfCount, maxPerfCount;
 
 /**
  * Function that computes 24 Keccak-f[1600] permutation rounds on the given state.
@@ -18,7 +20,7 @@ void KeccakF1600_StatePermute_vector(void *state)
     unsigned int round;
 
     unsigned long start, stop;
-    start = read_instret();
+    start = read_perf_counter();
     // initial loading of 5x5x64 state
     vuint64m4_t row0 = __riscv_vle64_v_u64m4(((uint64_t*)state) + 0, 5);
     vuint64m4_t row1 = __riscv_vle64_v_u64m4(((uint64_t*)state) + 5, 5);
@@ -194,10 +196,10 @@ void KeccakF1600_StatePermute_vector(void *state)
         __riscv_vse64_v_u64m4((uint64_t*)state + 20, row4, 5);
 
     }
-    stop = read_instret();
-    long cycleCnt = (stop - start);
+    stop = read_perf_counter();
+    long perfCnt = (stop - start);
     nCalls += 24;
-    totalEvts += cycleCnt;
-    if (cycleCnt < minLatency) minLatency = cycleCnt;
-    if (cycleCnt > maxLatency) maxLatency = cycleCnt;
+    totalEvts += perfCnt;
+    if (perfCnt < minPerfCount) minPerfCount = perfCnt;
+    if (perfCnt > maxPerfCount) maxPerfCount = perfCnt;
 }

--- a/src/keccak-vector-multi-round-new-layout.c
+++ b/src/keccak-vector-multi-round-new-layout.c
@@ -1,0 +1,260 @@
+#include <riscv_vector.h>
+#include <inttypes.h>
+#include <assert.h>
+#include <keccak-vector-common.h>
+
+#include "bench_utils.h"
+
+
+extern unsigned long totalEvts, nCalls, minPerfCount, maxPerfCount;
+
+void KeccakF1600_StatePermute_vector(void *state)
+{
+    unsigned int round;
+
+    unsigned long start, stop;
+    start = read_perf_counter();
+
+    // initial state loading
+    vuint64m4_t row0 = __riscv_vle64_v_u64m4(((uint64_t*)state) + 0, 5);
+    vuint64m4_t row1 = __riscv_vle64_v_u64m4(((uint64_t*)state) + 5, 5);
+    vuint64m4_t row2 = __riscv_vle64_v_u64m4(((uint64_t*)state) + 10, 5);
+    vuint64m4_t row3 = __riscv_vle64_v_u64m4(((uint64_t*)state) + 15, 5);
+    vuint64m4_t row4 = __riscv_vle64_v_u64m4(((uint64_t*)state) + 20, 5);
+
+#if defined(IN_MEMORY_RHO_PI) // do not define IN_MEMORY_RHO_PI to enable in-register rho and pi steps
+    // indices and rotations generated with script/utils.py
+    uint16_t offset_AtoB[] = {
+        // byte offset for each index
+        0, 48, 96, 144, 192, 
+        24, 72, 80, 128, 176, 
+        8, 56, 104, 152, 160, 
+        32, 40, 88, 136, 184, 
+        16, 64, 112, 120, 168, 
+    };
+    uint64_t rotation_B[] = {
+        0, 44, 43, 21, 14, 
+        28, 20, 3, 45, 61, 
+        1, 6, 25, 8, 18, 
+        27, 36, 10, 15, 56, 
+        62, 55, 39, 41, 2, 
+    };
+
+    vuint16m2_t B_index_0 = __riscv_vle16_v_u16m2(offset_AtoB, 16);
+    vuint16m2_t B_index_1 = __riscv_vle16_v_u16m2(offset_AtoB + 16, 9);
+    vuint64m8_t B_rots_0 = __riscv_vle64_v_u64m8(rotation_B, 16);
+    vuint64m8_t B_rots_1 = __riscv_vle64_v_u64m8(rotation_B + 16, 9);
+
+#else // !defined(IN_MEMORY_RHO_PI) in-register rho and pi steps
+            // indices and rotations generated with script/utils.py
+            uint16_t offsetByte_AtoB[] = {
+                // byte offset for each index
+                0, 48, 96, 144, 192, 
+                24, 72, 80, 128, 176, 
+                8, 56, 104, 152, 160, 
+                32, 40, 88, 136, 184, 
+                16, 64, 112, 120, 168, 
+            };
+            const uint16_t offsetIndex_AtoB[] = {
+                // index offset for each index
+                0, 6, 12, 18, 24, 
+                3, 9, 10, 16, 22, 
+                1, 7, 13, 19, 20, 
+                4, 5, 11, 17, 23, 
+                2, 8, 14, 15, 21, 
+            };
+            // index for each row (5-element) in rho_data_lo
+            // Note: -1 value triggers an index overflow (vrgather(ei16) will fill in the result element with 0)
+            const uint16_t offsetIndex_AtoB_lo[] = {
+                // index offset for each index
+                0, 6, 12, -1, -1, 
+                3, 9, 10, -1, -1, 
+                1, 7, 13, -1, -1, 
+                4, 5, 11, -1, -1, 
+                2, 8, 14, -1, -1, 
+            };
+            // index for each row (5-element) in rho_data_hi
+            // Note: -1 value triggers an index overflow (vrgather(ei16) will fill in the result element with 0)
+            const uint16_t offsetIndex_AtoB_hi[] = {
+                // index offset for each index
+                -1, -1, -1, 18 - 15, 24 - 20 + 8, 
+                -1, -1, -1, 16 - 15, 22 - 20 + 8, 
+                -1, -1, -1, 19 - 15, 20 - 20 + 8, 
+                -1, -1, -1, 17 - 15, 23 - 20 + 8, 
+                -1, -1, -1, 15 - 15, 21 - 20 + 8, 
+            };
+            uint64_t rotation_B[] = {
+                0, 44, 43, 21, 14, 
+                28, 20, 3, 45, 61, 
+                1, 6, 25, 8, 18, 
+                27, 36, 10, 15, 56, 
+                62, 55, 39, 41, 2, 
+            };
+
+            vuint16m2_t B_index_row0_lo = __riscv_vle16_v_u16m2(offsetIndex_AtoB_lo, 5);
+            vuint16m2_t B_index_row0_hi = __riscv_vle16_v_u16m2(offsetIndex_AtoB_hi, 5);
+
+            vuint16m2_t B_index_row1_lo = __riscv_vle16_v_u16m2(offsetIndex_AtoB_lo + 5, 5);
+            vuint16m2_t B_index_row1_hi = __riscv_vle16_v_u16m2(offsetIndex_AtoB_hi + 5, 5);
+
+            vuint16m2_t B_index_row2_lo = __riscv_vle16_v_u16m2(offsetIndex_AtoB_lo + 10, 5);
+            vuint16m2_t B_index_row2_hi = __riscv_vle16_v_u16m2(offsetIndex_AtoB_hi + 10, 5);
+
+            vuint16m2_t B_index_row3_lo = __riscv_vle16_v_u16m2(offsetIndex_AtoB_lo + 15, 5);
+            vuint16m2_t B_index_row3_hi = __riscv_vle16_v_u16m2(offsetIndex_AtoB_hi + 15, 5);
+
+            vuint16m2_t B_index_row4_lo = __riscv_vle16_v_u16m2(offsetIndex_AtoB_lo + 20, 5);
+            vuint16m2_t B_index_row4_hi = __riscv_vle16_v_u16m2(offsetIndex_AtoB_hi + 20, 5);
+
+#endif
+
+    for(round=0; round<24; round++) {
+        {   /* === θ step (see [Keccak Reference, Section 2.3.2]) === */
+            vuint64m4_t C_01 = __riscv_vxor_vv_u64m4(row0, row1, 5);
+            vuint64m4_t C_23 = __riscv_vxor_vv_u64m4(row2, row3, 5);
+            vuint64m4_t C_014 = __riscv_vxor_vv_u64m4(C_01, row4, 5);
+            vuint64m4_t C_vector = __riscv_vxor_vv_u64m4(C_23, C_014, 5);
+
+            /* Compute the θ effect for all the columns */
+            vuint64m4_t C_4_ext = __riscv_vslidedown_vx_u64m4(C_vector, 4, 1);       // {C[4]}
+            vuint64m4_t D_opHi = __riscv_vslideup_vx_u64m4(C_4_ext, C_vector, 1, 5); // {C[4],    C[0], C[1], C[2], C[3]}
+
+            vuint64m4_t D_opLo = __riscv_vslidedown_vx_u64m4(C_vector, 1, 5); // {C[1], C[2], C[3], C[4], 0}
+            D_opLo = __riscv_vslideup_vx_u64m4(D_opLo, C_vector, 4, 5);       // {C[1], C[2], C[3], C[4], C[0]}
+            D_opLo = __riscv_vrol_vx_u64m4(D_opLo, 1, 5);
+            vuint64m4_t D = __riscv_vxor_vv_u64m4(D_opLo, D_opHi, 5);
+            
+            /* Apply the θ effect */
+            row0 = __riscv_vxor_vv_u64m4(row0, D, 5);
+            row1 = __riscv_vxor_vv_u64m4(row1, D, 5);
+            row2 = __riscv_vxor_vv_u64m4(row2, D, 5);
+            row3 = __riscv_vxor_vv_u64m4(row3, D, 5);
+            row4 = __riscv_vxor_vv_u64m4(row4, D, 5);
+
+        }
+#       if defined(IN_MEMORY_RHO_PI) // do not define IN_MEMORY_RHO_PI to enable in-register rho and pi steps
+        /* === in-memory ρ and π steps */
+        {
+
+            __riscv_vse64_v_u64m4((uint64_t*)state,      row0, 5);
+            __riscv_vse64_v_u64m4((uint64_t*)state + 5,  row1, 5);
+            __riscv_vse64_v_u64m4((uint64_t*)state + 10, row2, 5);
+            __riscv_vse64_v_u64m4((uint64_t*)state + 15, row3, 5);
+            __riscv_vse64_v_u64m4((uint64_t*)state + 20, row4, 5);
+        }
+        {
+
+            // The following assumes VLEN >= 128, and uses 2x 8-register groups to load/transpose 
+            // matrix A to B
+            // First 16 elements [0...15]
+            vuint64m8_t B_0 = __riscv_vluxei16_v_u64m8(state, B_index_0, 16);
+            B_0 = __riscv_vrol_vv_u64m8(B_0, B_rots_0, 16);
+            // Last 9 elements [16...24]
+            vuint64m8_t B_1 = __riscv_vluxei16_v_u64m8(state, B_index_1, 9);
+            B_1 = __riscv_vrol_vv_u64m8(B_1, B_rots_1, 9);
+            // To avoid state corruption, B partial results can only be stored once indexed load accesses
+            // have all been completed.
+            __riscv_vse64_v_u64m8((uint64_t*)state, B_0, 16);
+            __riscv_vse64_v_u64m8((uint64_t*)state + 16, B_1, 9);
+        }
+
+        {
+            row0 = __riscv_vle64_v_u64m4(((uint64_t*)state) + 0, 5);
+            row1 = __riscv_vle64_v_u64m4(((uint64_t*)state) + 5, 5);
+            row2 = __riscv_vle64_v_u64m4(((uint64_t*)state) + 10, 5);
+            row3 = __riscv_vle64_v_u64m4(((uint64_t*)state) + 15, 5);
+            row4 = __riscv_vle64_v_u64m4(((uint64_t*)state) + 20, 5);
+        }
+#       else // !defined(IN_MEMORY_RHO_PI) in-memory rho and pi steps
+        /* === in-register ρ and π steps === */
+        {
+            // building two inputs set
+            // first set {row0[0..4], row1[0..4], row2[0..4], 0}
+            row0 = __riscv_vslideup_vx_u64m4(row0, row1, 5, 8);
+            row1 = __riscv_vslidedown_vx_u64m4(row1, 3, 3);
+            row2 = __riscv_vslideup_vx_u64m4(row1, row2, 2, 8);
+            vuint64m8_t rho_data_lo = __riscv_vcreate_v_u64m4_u64m8(row0, row2);
+            // second set {row3[0..4], 0, 0, 0, row4[0..4], 0, 0, 0}
+            vuint64m8_t rho_data_hi = __riscv_vcreate_v_u64m4_u64m8(row3, row4);
+            row0 = __riscv_vor_vv_u64m4(
+                __riscv_vget_v_u64m8_u64m4(__riscv_vrgatherei16_vv_u64m8(rho_data_lo, B_index_row0_lo, 5), 0),
+                __riscv_vget_v_u64m8_u64m4(__riscv_vrgatherei16_vv_u64m8(rho_data_hi, B_index_row0_hi, 5), 0),
+                5
+            );
+            row0 = __riscv_vrol_vv_u64m4(row0, __riscv_vle64_v_u64m4(rotation_B + 0 * 5, 5), 5);
+
+            row1 = __riscv_vor_vv_u64m4(
+                __riscv_vget_v_u64m8_u64m4(__riscv_vrgatherei16_vv_u64m8(rho_data_lo, B_index_row1_lo, 5), 0),
+                __riscv_vget_v_u64m8_u64m4(__riscv_vrgatherei16_vv_u64m8(rho_data_hi, B_index_row1_hi, 5), 0),
+                5
+            );
+            row1 = __riscv_vrol_vv_u64m4(row1, __riscv_vle64_v_u64m4(rotation_B + 1 * 5, 5), 5);
+
+            row2 = __riscv_vor_vv_u64m4(
+                __riscv_vget_v_u64m8_u64m4(__riscv_vrgatherei16_vv_u64m8(rho_data_lo, B_index_row2_lo, 5), 0),
+                __riscv_vget_v_u64m8_u64m4(__riscv_vrgatherei16_vv_u64m8(rho_data_hi, B_index_row2_hi, 5), 0),
+                5
+            );
+            row2 = __riscv_vrol_vv_u64m4(row2, __riscv_vle64_v_u64m4(rotation_B + 2 * 5, 5), 5);
+
+            row3 = __riscv_vor_vv_u64m4(
+                __riscv_vget_v_u64m8_u64m4(__riscv_vrgatherei16_vv_u64m8(rho_data_lo, B_index_row3_lo, 5), 0),
+                __riscv_vget_v_u64m8_u64m4(__riscv_vrgatherei16_vv_u64m8(rho_data_hi, B_index_row3_hi, 5), 0),
+                5
+            );
+            row3 = __riscv_vrol_vv_u64m4(row3, __riscv_vle64_v_u64m4(rotation_B + 3 * 5, 5), 5);
+
+            row4 = __riscv_vor_vv_u64m4(
+                __riscv_vget_v_u64m8_u64m4(__riscv_vrgatherei16_vv_u64m8(rho_data_lo, B_index_row4_lo, 5), 0),
+                __riscv_vget_v_u64m8_u64m4(__riscv_vrgatherei16_vv_u64m8(rho_data_hi, B_index_row4_hi, 5), 0),
+                5
+            );
+            row4 = __riscv_vrol_vv_u64m4(row4, __riscv_vle64_v_u64m4(rotation_B + 4 * 5, 5), 5);
+        }
+#       endif
+
+        /* === χ step (see [Keccak Reference, Section 2.3.1]) === */
+        {
+            const uint16_t xp1_indices_buf[5] = {1, 2, 3, 4, 0};
+            const uint16_t xp2_indices_buf[5] = {2, 3, 4, 0, 1};
+            vuint16m1_t xp1_indices = __riscv_vle16_v_u16m1(xp1_indices_buf, 5); 
+            vuint16m1_t xp2_indices = __riscv_vle16_v_u16m1(xp2_indices_buf, 5); 
+            vuint64m4_t row0_xp1 = __riscv_vrgatherei16_vv_u64m4(row0, xp1_indices, 5);
+            vuint64m4_t row0_xp2 = __riscv_vrgatherei16_vv_u64m4(row0, xp2_indices, 5);
+            row0 = __riscv_vxor_vv_u64m4(row0, __riscv_vandn_vv_u64m4(row0_xp2, row0_xp1, 5), 5);
+
+            /* === ι step (see [Keccak Reference, Section 2.3.5]) === */
+            row0 = __riscv_vxor_vx_u64m4_tu(row0, row0, RC[round], 1);
+
+            vuint64m4_t row1_xp1 = __riscv_vrgatherei16_vv_u64m4(row1, xp1_indices, 5);
+            vuint64m4_t row1_xp2 = __riscv_vrgatherei16_vv_u64m4(row1, xp2_indices, 5);
+            row1 = __riscv_vxor_vv_u64m4(row1, __riscv_vandn_vv_u64m4(row1_xp2, row1_xp1, 5), 5);
+
+            vuint64m4_t row2_xp1 = __riscv_vrgatherei16_vv_u64m4(row2, xp1_indices, 5);
+            vuint64m4_t row2_xp2 = __riscv_vrgatherei16_vv_u64m4(row2, xp2_indices, 5);
+            row2 = __riscv_vxor_vv_u64m4(row2, __riscv_vandn_vv_u64m4(row2_xp2, row2_xp1, 5), 5);
+
+            vuint64m4_t row3_xp1 = __riscv_vrgatherei16_vv_u64m4(row3, xp1_indices, 5);
+            vuint64m4_t row3_xp2 = __riscv_vrgatherei16_vv_u64m4(row3, xp2_indices, 5);
+            row3 = __riscv_vxor_vv_u64m4(row3, __riscv_vandn_vv_u64m4(row3_xp2, row3_xp1, 5), 5);
+
+            vuint64m4_t row4_xp1 = __riscv_vrgatherei16_vv_u64m4(row4, xp1_indices, 5);
+            vuint64m4_t row4_xp2 = __riscv_vrgatherei16_vv_u64m4(row4, xp2_indices, 5);
+            row4 = __riscv_vxor_vv_u64m4(row4, __riscv_vandn_vv_u64m4(row4_xp2, row4_xp1, 5), 5);
+        }
+    }
+
+    // final state storing (after 24-round execution)
+    __riscv_vse64_v_u64m4((uint64_t*)state,      row0, 5);
+    __riscv_vse64_v_u64m4((uint64_t*)state + 5,  row1, 5);
+    __riscv_vse64_v_u64m4((uint64_t*)state + 10, row2, 5);
+    __riscv_vse64_v_u64m4((uint64_t*)state + 15, row3, 5);
+    __riscv_vse64_v_u64m4((uint64_t*)state + 20, row4, 5);
+
+    stop = read_perf_counter();
+    long perfCnt = (stop - start);
+    nCalls += 24;
+    totalEvts += perfCnt;
+    if (perfCnt < minPerfCount) minPerfCount = perfCnt;
+    if (perfCnt > maxPerfCount) maxPerfCount = perfCnt;
+}

--- a/src/keccak-vector-multi-round.c
+++ b/src/keccak-vector-multi-round.c
@@ -46,7 +46,7 @@ void KeccakF1600_StatePermute_vector(void *state)
             row4 = __riscv_vxor_vv_u64m4(row4, D, 5);
 
         }
-#       if 1 // set to 0 to enable in-register rho and pi steps
+#       if defined(IN_MEMORY_RHO_PI) // do not define IN_MEMORY_RHO_PI to enable in-register rho and pi steps
         /* === in-memory ρ and π steps */
         {
 
@@ -99,7 +99,7 @@ void KeccakF1600_StatePermute_vector(void *state)
             row3 = __riscv_vle64_v_u64m4(((uint64_t*)state) + 15, 5);
             row4 = __riscv_vle64_v_u64m4(((uint64_t*)state) + 20, 5);
         }
-#       else // in-memory rho and pi steps
+#       else // !defined(IN_MEMORY_RHO_PI) in-memory rho and pi steps
         /* === in-register ρ and π steps === */
         {
             // building two inputs set

--- a/src/keccak-vector-multi-round.c
+++ b/src/keccak-vector-multi-round.c
@@ -22,6 +22,31 @@ void KeccakF1600_StatePermute_vector(void *state)
     vuint64m4_t row3 = __riscv_vle64_v_u64m4(((uint64_t*)state) + 15, 5);
     vuint64m4_t row4 = __riscv_vle64_v_u64m4(((uint64_t*)state) + 20, 5);
 
+#if defined(IN_MEMORY_RHO_PI) // do not define IN_MEMORY_RHO_PI to enable in-register rho and pi steps
+    // indices and rotations generated with script/utils.py
+    uint16_t offset_AtoB[] = {
+        // byte offset for each index
+        0, 48, 96, 144, 192, 
+        24, 72, 80, 128, 176, 
+        8, 56, 104, 152, 160, 
+        32, 40, 88, 136, 184, 
+        16, 64, 112, 120, 168, 
+    };
+    uint64_t rotation_B[] = {
+        0, 44, 43, 21, 14, 
+        28, 20, 3, 45, 61, 
+        1, 6, 25, 8, 18, 
+        27, 36, 10, 15, 56, 
+        62, 55, 39, 41, 2, 
+    };
+
+    vuint16m2_t B_index_0 = __riscv_vle16_v_u16m2(offset_AtoB, 16);
+    vuint16m2_t B_index_1 = __riscv_vle16_v_u16m2(offset_AtoB + 16, 9);
+    vuint64m8_t B_rots_0 = __riscv_vle64_v_u64m8(rotation_B, 16);
+    vuint64m8_t B_rots_1 = __riscv_vle64_v_u64m8(rotation_B + 16, 9);
+
+#endif
+
     for(round=0; round<24; round++) {
         {   /* === θ step (see [Keccak Reference, Section 2.3.2]) === */
             vuint64m4_t C_01 = __riscv_vxor_vv_u64m4(row0, row1, 5);
@@ -57,34 +82,14 @@ void KeccakF1600_StatePermute_vector(void *state)
             __riscv_vse64_v_u64m4((uint64_t*)state + 20, row4, 5);
         }
         {
-            // indices and rotations generated with script/utils.py
-            uint16_t offset_AtoB[] = {
-                // byte offset for each index
-                0, 48, 96, 144, 192, 
-                24, 72, 80, 128, 176, 
-                8, 56, 104, 152, 160, 
-                32, 40, 88, 136, 184, 
-                16, 64, 112, 120, 168, 
-            };
-            uint64_t rotation_B[] = {
-                0, 44, 43, 21, 14, 
-                28, 20, 3, 45, 61, 
-                1, 6, 25, 8, 18, 
-                27, 36, 10, 15, 56, 
-                62, 55, 39, 41, 2, 
-            };
 
             // The following assumes VLEN >= 128, and uses 2x 8-register groups to load/transpose 
             // matrix A to B
             // First 16 elements [0...15]
-            vuint16m2_t B_index_0 = __riscv_vle16_v_u16m2(offset_AtoB, 16);
             vuint64m8_t B_0 = __riscv_vluxei16_v_u64m8(state, B_index_0, 16);
-            vuint64m8_t B_rots_0 = __riscv_vle64_v_u64m8(rotation_B, 16);
             B_0 = __riscv_vrol_vv_u64m8(B_0, B_rots_0, 16);
             // Last 9 elements [16...24]
-            vuint16m2_t B_index_1 = __riscv_vle16_v_u16m2(offset_AtoB + 16, 9);
             vuint64m8_t B_1 = __riscv_vluxei16_v_u64m8(state, B_index_1, 9);
-            vuint64m8_t B_rots_1 = __riscv_vle64_v_u64m8(rotation_B + 16, 9);
             B_1 = __riscv_vrol_vv_u64m8(B_1, B_rots_1, 9);
             // To avoid state corruption, B partial results can only be stored once indexed load accesses
             // have all been completed.

--- a/src/keccak-vector-multi-round.c
+++ b/src/keccak-vector-multi-round.c
@@ -45,6 +45,67 @@ void KeccakF1600_StatePermute_vector(void *state)
     vuint64m8_t B_rots_0 = __riscv_vle64_v_u64m8(rotation_B, 16);
     vuint64m8_t B_rots_1 = __riscv_vle64_v_u64m8(rotation_B + 16, 9);
 
+#else // !defined(IN_MEMORY_RHO_PI) in-register rho and pi steps
+            // indices and rotations generated with script/utils.py
+            uint16_t offsetByte_AtoB[] = {
+                // byte offset for each index
+                0, 48, 96, 144, 192, 
+                24, 72, 80, 128, 176, 
+                8, 56, 104, 152, 160, 
+                32, 40, 88, 136, 184, 
+                16, 64, 112, 120, 168, 
+            };
+            const uint16_t offsetIndex_AtoB[] = {
+                // index offset for each index
+                0, 6, 12, 18, 24, 
+                3, 9, 10, 16, 22, 
+                1, 7, 13, 19, 20, 
+                4, 5, 11, 17, 23, 
+                2, 8, 14, 15, 21, 
+            };
+            // index for each row (5-element) in rho_data_lo
+            // Note: -1 value triggers an index overflow (vrgather(ei16) will fill in the result element with 0)
+            const uint16_t offsetIndex_AtoB_lo[] = {
+                // index offset for each index
+                0, 6, 12, -1, -1, 
+                3, 9, 10, -1, -1, 
+                1, 7, 13, -1, -1, 
+                4, 5, 11, -1, -1, 
+                2, 8, 14, -1, -1, 
+            };
+            // index for each row (5-element) in rho_data_hi
+            // Note: -1 value triggers an index overflow (vrgather(ei16) will fill in the result element with 0)
+            const uint16_t offsetIndex_AtoB_hi[] = {
+                // index offset for each index
+                -1, -1, -1, 18 - 15, 24 - 20 + 8, 
+                -1, -1, -1, 16 - 15, 22 - 20 + 8, 
+                -1, -1, -1, 19 - 15, 20 - 20 + 8, 
+                -1, -1, -1, 17 - 15, 23 - 20 + 8, 
+                -1, -1, -1, 15 - 15, 21 - 20 + 8, 
+            };
+            uint64_t rotation_B[] = {
+                0, 44, 43, 21, 14, 
+                28, 20, 3, 45, 61, 
+                1, 6, 25, 8, 18, 
+                27, 36, 10, 15, 56, 
+                62, 55, 39, 41, 2, 
+            };
+
+            vuint16m2_t B_index_row0_lo = __riscv_vle16_v_u16m2(offsetIndex_AtoB_lo, 5);
+            vuint16m2_t B_index_row0_hi = __riscv_vle16_v_u16m2(offsetIndex_AtoB_hi, 5);
+
+            vuint16m2_t B_index_row1_lo = __riscv_vle16_v_u16m2(offsetIndex_AtoB_lo + 5, 5);
+            vuint16m2_t B_index_row1_hi = __riscv_vle16_v_u16m2(offsetIndex_AtoB_hi + 5, 5);
+
+            vuint16m2_t B_index_row2_lo = __riscv_vle16_v_u16m2(offsetIndex_AtoB_lo + 10, 5);
+            vuint16m2_t B_index_row2_hi = __riscv_vle16_v_u16m2(offsetIndex_AtoB_hi + 10, 5);
+
+            vuint16m2_t B_index_row3_lo = __riscv_vle16_v_u16m2(offsetIndex_AtoB_lo + 15, 5);
+            vuint16m2_t B_index_row3_hi = __riscv_vle16_v_u16m2(offsetIndex_AtoB_hi + 15, 5);
+
+            vuint16m2_t B_index_row4_lo = __riscv_vle16_v_u16m2(offsetIndex_AtoB_lo + 20, 5);
+            vuint16m2_t B_index_row4_hi = __riscv_vle16_v_u16m2(offsetIndex_AtoB_hi + 20, 5);
+
 #endif
 
     for(round=0; round<24; round++) {
@@ -115,53 +176,6 @@ void KeccakF1600_StatePermute_vector(void *state)
             vuint64m8_t rho_data_lo = __riscv_vcreate_v_u64m4_u64m8(row0, row2);
             // second set {row3[0..4], 0, 0, 0, row4[0..4], 0, 0, 0}
             vuint64m8_t rho_data_hi = __riscv_vcreate_v_u64m4_u64m8(row3, row4);
-            // indices and rotations generated with script/utils.py
-            uint16_t offsetByte_AtoB[] = {
-                // byte offset for each index
-                0, 48, 96, 144, 192, 
-                24, 72, 80, 128, 176, 
-                8, 56, 104, 152, 160, 
-                32, 40, 88, 136, 184, 
-                16, 64, 112, 120, 168, 
-            };
-            const uint16_t offsetIndex_AtoB[] = {
-                // index offset for each index
-                0, 6, 12, 18, 24, 
-                3, 9, 10, 16, 22, 
-                1, 7, 13, 19, 20, 
-                4, 5, 11, 17, 23, 
-                2, 8, 14, 15, 21, 
-            };
-            // index for each row (5-element) in rho_data_lo
-            // Note: -1 value triggers an index overflow (vrgather(ei16) will fill in the result element with 0)
-            const uint16_t offsetIndex_AtoB_lo[] = {
-                // index offset for each index
-                0, 6, 12, -1, -1, 
-                3, 9, 10, -1, -1, 
-                1, 7, 13, -1, -1, 
-                4, 5, 11, -1, -1, 
-                2, 8, 14, -1, -1, 
-            };
-            // index for each row (5-element) in rho_data_hi
-            // Note: -1 value triggers an index overflow (vrgather(ei16) will fill in the result element with 0)
-            const uint16_t offsetIndex_AtoB_hi[] = {
-                // index offset for each index
-                -1, -1, -1, 18 - 15, 24 - 20 + 8, 
-                -1, -1, -1, 16 - 15, 22 - 20 + 8, 
-                -1, -1, -1, 19 - 15, 20 - 20 + 8, 
-                -1, -1, -1, 17 - 15, 23 - 20 + 8, 
-                -1, -1, -1, 15 - 15, 21 - 20 + 8, 
-            };
-            uint64_t rotation_B[] = {
-                0, 44, 43, 21, 14, 
-                28, 20, 3, 45, 61, 
-                1, 6, 25, 8, 18, 
-                27, 36, 10, 15, 56, 
-                62, 55, 39, 41, 2, 
-            };
-
-            vuint16m2_t B_index_row0_lo = __riscv_vle16_v_u16m2(offsetIndex_AtoB_lo, 5);
-            vuint16m2_t B_index_row0_hi = __riscv_vle16_v_u16m2(offsetIndex_AtoB_hi, 5);
             row0 = __riscv_vor_vv_u64m4(
                 __riscv_vget_v_u64m8_u64m4(__riscv_vrgatherei16_vv_u64m8(rho_data_lo, B_index_row0_lo, 5), 0),
                 __riscv_vget_v_u64m8_u64m4(__riscv_vrgatherei16_vv_u64m8(rho_data_hi, B_index_row0_hi, 5), 0),
@@ -169,8 +183,6 @@ void KeccakF1600_StatePermute_vector(void *state)
             );
             row0 = __riscv_vrol_vv_u64m4(row0, __riscv_vle64_v_u64m4(rotation_B + 0 * 5, 5), 5);
 
-            vuint16m2_t B_index_row1_lo = __riscv_vle16_v_u16m2(offsetIndex_AtoB_lo + 5, 5);
-            vuint16m2_t B_index_row1_hi = __riscv_vle16_v_u16m2(offsetIndex_AtoB_hi + 5, 5);
             row1 = __riscv_vor_vv_u64m4(
                 __riscv_vget_v_u64m8_u64m4(__riscv_vrgatherei16_vv_u64m8(rho_data_lo, B_index_row1_lo, 5), 0),
                 __riscv_vget_v_u64m8_u64m4(__riscv_vrgatherei16_vv_u64m8(rho_data_hi, B_index_row1_hi, 5), 0),
@@ -178,8 +190,6 @@ void KeccakF1600_StatePermute_vector(void *state)
             );
             row1 = __riscv_vrol_vv_u64m4(row1, __riscv_vle64_v_u64m4(rotation_B + 1 * 5, 5), 5);
 
-            vuint16m2_t B_index_row2_lo = __riscv_vle16_v_u16m2(offsetIndex_AtoB_lo + 10, 5);
-            vuint16m2_t B_index_row2_hi = __riscv_vle16_v_u16m2(offsetIndex_AtoB_hi + 10, 5);
             row2 = __riscv_vor_vv_u64m4(
                 __riscv_vget_v_u64m8_u64m4(__riscv_vrgatherei16_vv_u64m8(rho_data_lo, B_index_row2_lo, 5), 0),
                 __riscv_vget_v_u64m8_u64m4(__riscv_vrgatherei16_vv_u64m8(rho_data_hi, B_index_row2_hi, 5), 0),
@@ -187,8 +197,6 @@ void KeccakF1600_StatePermute_vector(void *state)
             );
             row2 = __riscv_vrol_vv_u64m4(row2, __riscv_vle64_v_u64m4(rotation_B + 2 * 5, 5), 5);
 
-            vuint16m2_t B_index_row3_lo = __riscv_vle16_v_u16m2(offsetIndex_AtoB_lo + 15, 5);
-            vuint16m2_t B_index_row3_hi = __riscv_vle16_v_u16m2(offsetIndex_AtoB_hi + 15, 5);
             row3 = __riscv_vor_vv_u64m4(
                 __riscv_vget_v_u64m8_u64m4(__riscv_vrgatherei16_vv_u64m8(rho_data_lo, B_index_row3_lo, 5), 0),
                 __riscv_vget_v_u64m8_u64m4(__riscv_vrgatherei16_vv_u64m8(rho_data_hi, B_index_row3_hi, 5), 0),
@@ -196,8 +204,6 @@ void KeccakF1600_StatePermute_vector(void *state)
             );
             row3 = __riscv_vrol_vv_u64m4(row3, __riscv_vle64_v_u64m4(rotation_B + 3 * 5, 5), 5);
 
-            vuint16m2_t B_index_row4_lo = __riscv_vle16_v_u16m2(offsetIndex_AtoB_lo + 20, 5);
-            vuint16m2_t B_index_row4_hi = __riscv_vle16_v_u16m2(offsetIndex_AtoB_hi + 20, 5);
             row4 = __riscv_vor_vv_u64m4(
                 __riscv_vget_v_u64m8_u64m4(__riscv_vrgatherei16_vv_u64m8(rho_data_lo, B_index_row4_lo, 5), 0),
                 __riscv_vget_v_u64m8_u64m4(__riscv_vrgatherei16_vv_u64m8(rho_data_hi, B_index_row4_hi, 5), 0),

--- a/src/keccak-vector-multi-round.c
+++ b/src/keccak-vector-multi-round.c
@@ -1,20 +1,19 @@
 #include <riscv_vector.h>
-#include <stdio.h>
-#include <string.h>
 #include <inttypes.h>
 #include <assert.h>
 #include <keccak-vector-common.h>
 
+#include "bench_utils.h"
 
 
-extern unsigned long totalEvts, nCalls, minLatency, maxLatency;
+extern unsigned long totalEvts, nCalls, minPerfCount, maxPerfCount;
 
 void KeccakF1600_StatePermute_vector(void *state)
 {
     unsigned int round;
 
     unsigned long start, stop;
-    start = read_instret();
+    start = read_perf_counter();
 
     // initial state loading
     vuint64m4_t row0 = __riscv_vle64_v_u64m4(((uint64_t*)state) + 0, 5);
@@ -241,10 +240,10 @@ void KeccakF1600_StatePermute_vector(void *state)
     __riscv_vse64_v_u64m4((uint64_t*)state + 15, row3, 5);
     __riscv_vse64_v_u64m4((uint64_t*)state + 20, row4, 5);
 
-    stop = read_instret();
-    long cycleCnt = (stop - start);
+    stop = read_perf_counter();
+    long perfCnt = (stop - start);
     nCalls += 24;
-    totalEvts += cycleCnt;
-    if (cycleCnt < minLatency) minLatency = cycleCnt;
-    if (cycleCnt > maxLatency) maxLatency = cycleCnt;
+    totalEvts += perfCnt;
+    if (perfCnt < minPerfCount) minPerfCount = perfCnt;
+    if (perfCnt > maxPerfCount) maxPerfCount = perfCnt;
 }

--- a/src/keccak-vector.c
+++ b/src/keccak-vector.c
@@ -6,6 +6,8 @@
 
 #include "keccak-vector-common.h"
 
+#include "bench_utils.h"
+
 
 /** RVV implementation of Keccak-F1600 round function 
  * Function that computes the Keccak-f[1600] permutation on the given state.
@@ -117,7 +119,7 @@ void KeccakF1600_Round_vector(void *state, unsigned round)
 */
 void KeccakF1600_Round_vector(void *state, unsigned round);
 
-extern unsigned long totalEvts, nCalls, minLatency, maxLatency;
+extern unsigned long totalEvts, nCalls, minPerfCount, maxPerfCount;
 
 void KeccakF1600_StatePermute_vector(void *state)
 {
@@ -125,14 +127,14 @@ void KeccakF1600_StatePermute_vector(void *state)
 
     for(round=0; round<24; round++) {
         unsigned long start, stop;
-        start = read_instret();
+        start = read_perf_counter();
         KeccakF1600_Round_vector(state, round);
-        stop = read_instret();
-        long cycleCnt = (stop - start);
+        stop = read_perf_counter();
+        long perfCnt = (stop - start);
         nCalls++;
-        totalEvts += cycleCnt;
-        if (cycleCnt < minLatency) minLatency = cycleCnt;
-        if (cycleCnt > maxLatency) maxLatency = cycleCnt;
+        totalEvts += perfCnt;
+        if (perfCnt < minPerfCount) minPerfCount = perfCnt;
+        if (perfCnt > maxPerfCount) maxPerfCount = perfCnt;
 
     }
 }


### PR DESCRIPTION
- Extending Makefile to make building on CanMV K230 easier
- Refactoring performance count mechanism to allow selection between cycle count and retired instruction count (reusing `bench_utils.h` from rev-examples)